### PR TITLE
Bump Pagefind version and add support for Pagefind configuration options.

### DIFF
--- a/pagefind/README.md
+++ b/pagefind/README.md
@@ -4,7 +4,7 @@ The [Cherokee Myths](https://github.com/WebOrigami/cherokee-myths) sample site d
 
 ## Usage
 
-1. Add this `@weborigami/pagefine` extension to your Origami project's dependencies and `npm install`.
+1. Add this `@weborigami/pagefind` extension to your Origami project's dependencies and `npm install`.
 2. Add a link to your site's definition to invoke Pagefind. Pass in the tree of content you would like it to index; see below for how to do this.
 3. Add a search page like `search.html` to your site. This page will need to reference the Pagefind CSS and JavaScript files. It will also need to define a search box element, add an event handler to upgrade that element on page load to a useable search box.
 
@@ -70,7 +70,7 @@ If you have multiple areas, you can pass them together:
 During local development of your site, the above definition will regenerate the `pagefind` area each time you visit it. To avoid that, you can wrap the `pagefind/` definition in a call to the [once](https://weborigami.org/builtins/origami/once) builtin. This will only call Pagefind the first time any resource in the `pagefind/` area is requested.
 
 ```
-  pagefind/ = once(() => package:@weborigami/pagefind({ stories }))
+  pagefind/ = Origami.once(() => package:@weborigami/pagefind({ stories }))
 ```
 
 ### Identifying the indexable parts of your site
@@ -90,6 +90,18 @@ If you have many things you'd like to include, it may be helpful to name all the
   ...indexable
   
   // And also index all that content
-  pagefind/ = once(() => package:@weborigami/pagefind(indexable))
+  pagefind/ = Origami.once(() => package:@weborigami/pagefind(indexable))
 }
+```
+
+### Using Pagefind configuration options
+
+You can supply [Pagefind configuration options](https://pagefind.app/docs/config-options/) by writing them in camelCase.
+
+```
+  pagefind/ = Origami.once(() => package:@weborigami/pagefind(indexable, {
+    rootSelector: "main",
+    forceLanguage: "en",
+    writePlayground: true
+  }))
 ```

--- a/pagefind/README.md
+++ b/pagefind/README.md
@@ -99,7 +99,7 @@ If you have many things you'd like to include, it may be helpful to name all the
 You can supply [Pagefind configuration options](https://pagefind.app/docs/config-options/) by writing them in camelCase.
 
 ```
-  pagefind/ = Origami.once(() => package:@weborigami/pagefind(indexable, {
+  pagefind/ = Origami.once(() => package:@weborigami/pagefind(indexable, "", {
     rootSelector: "main",
     forceLanguage: "en",
     writePlayground: true

--- a/pagefind/package-lock.json
+++ b/pagefind/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@weborigami/pagefind",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weborigami/pagefind",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
-        "@weborigami/async-tree": "0.4.1",
-        "pagefind": "1.3.0"
+        "@weborigami/async-tree": "0.5.1",
+        "pagefind": "1.4.0"
       }
     },
     "node_modules/@pagefind/darwin-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
-      "integrity": "sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
       "cpu": [
         "arm64"
       ],
@@ -26,9 +26,9 @@
       ]
     },
     "node_modules/@pagefind/darwin-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz",
-      "integrity": "sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
       "cpu": [
         "x64"
       ],
@@ -38,10 +38,23 @@
         "darwin"
       ]
     },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@pagefind/linux-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz",
-      "integrity": "sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
       "cpu": [
         "arm64"
       ],
@@ -52,9 +65,9 @@
       ]
     },
     "node_modules/@pagefind/linux-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz",
-      "integrity": "sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
       "cpu": [
         "x64"
       ],
@@ -65,9 +78,9 @@
       ]
     },
     "node_modules/@pagefind/windows-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz",
-      "integrity": "sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
       "cpu": [
         "x64"
       ],
@@ -78,32 +91,33 @@
       ]
     },
     "node_modules/@weborigami/async-tree": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@weborigami/async-tree/-/async-tree-0.4.1.tgz",
-      "integrity": "sha512-LYLpDQWN9pHjQfURlfT5g3juugZTCxOLedkAjVIG/aE/v8LVAYmM+ERwT2wbT11JqRD1I8R/hGnjl93GFV430Q==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@weborigami/async-tree/-/async-tree-0.5.1.tgz",
+      "integrity": "sha512-qGo+b4AJp1KWq1HLsCvM3UUBC5b03ZVdToPcSioiSjdMLQRNBoVuElP5mvd/0nFMah1rg4qGf7lQLdlLoryIzw==",
       "dependencies": {
-        "@weborigami/types": "0.4.1"
+        "@weborigami/types": "0.5.1"
       }
     },
     "node_modules/@weborigami/types": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@weborigami/types/-/types-0.4.1.tgz",
-      "integrity": "sha512-Nw0DXMeROsnZ7onWSk4WluXPN0tJYTat5PeECY0aSIH3yK3uvhxBGmAIncfZYY7dlATZ3q+OLKWraLj+vmshCQ=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@weborigami/types/-/types-0.5.1.tgz",
+      "integrity": "sha512-Trybsq6ehwYcjvcxMxT2I4D0+7wcDZL9d4tdb5x0zd45INQ3GjmPel8aZG4C2hxhYyYumboloLqvl9OdEQxb2Q=="
     },
     "node_modules/pagefind": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.3.0.tgz",
-      "integrity": "sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
       "license": "MIT",
       "bin": {
         "pagefind": "lib/runner/bin.cjs"
       },
       "optionalDependencies": {
-        "@pagefind/darwin-arm64": "1.3.0",
-        "@pagefind/darwin-x64": "1.3.0",
-        "@pagefind/linux-arm64": "1.3.0",
-        "@pagefind/linux-x64": "1.3.0",
-        "@pagefind/windows-x64": "1.3.0"
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     }
   }

--- a/pagefind/package.json
+++ b/pagefind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weborigami/pagefind",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "src/indexTree.js",
   "dependencies": {

--- a/pagefind/package.json
+++ b/pagefind/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "src/indexTree.js",
   "dependencies": {
-    "@weborigami/async-tree": "0.4.1",
-    "pagefind": "1.3.0"
+    "@weborigami/async-tree": "0.5.1",
+    "pagefind": "1.4.0"
   }
 }

--- a/pagefind/src/indexTree.js
+++ b/pagefind/src/indexTree.js
@@ -11,10 +11,11 @@ const TypedArray = Object.getPrototypeOf(Uint8Array);
  * @typedef {import("@weborigami/async-tree").Treelike} Treelike
  * @param {Treelike} treelike
  * @param {string} [basePath]
+ * @param {Object} [config] - Pagefind configuration options (camelCase)
  * @returns {Treelike}
  */
-export default async function indexTree(treelike, basePath = "") {
-  const { index } = await pagefind.createIndex();
+export default async function indexTree(treelike, basePath = "", config = {}) {
+  const { index } = await pagefind.createIndex(config);
 
   // Add everything in the input tree to the index.
   await addTreeToIndex(treelike, { index, basePath });


### PR DESCRIPTION
This PR bumps Pagefind's version to `1.4.0`, bumps async-tree's version to `0.5.1`, allows for using Pagefind's configuration options, and documents the new functionality.

You can test it on Vale.Rocks by switching out:

```ori
pagefind = Origami.once(() => package:@weborigami/pagefind(site))
```

for:

```
pagefind = Origami.once(() => package:@weborigami/pagefind(site, "", {
  writePlayground: true
}))
```

and then running a build.

You should observe the presence of `/build/pagefind/playground`.

I don't believe this introduces any breaking changes.